### PR TITLE
Add support for items partial updates

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,4 +31,6 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.5.1"
 }

--- a/example/src/main/java/com/mattskala/itemadapter/example/MainActivity.kt
+++ b/example/src/main/java/com/mattskala/itemadapter/example/MainActivity.kt
@@ -1,13 +1,20 @@
 package com.mattskala.itemadapter.example
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.mattskala.itemadapter.*
+import com.mattskala.itemadapter.BindingItemRenderer
+import com.mattskala.itemadapter.Item
+import com.mattskala.itemadapter.ItemAdapter
 import com.mattskala.itemadapter.example.databinding.ItemExampleBinding
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class MainActivity : AppCompatActivity() {
     companion object {
@@ -16,21 +23,29 @@ class MainActivity : AppCompatActivity() {
 
     private val adapter = ItemAdapter()
 
+    private val allItems = MutableStateFlow(createItems())
+    private val selectedItems = MutableStateFlow(emptySet<Int>())
+    private val selectableItems = combine(allItems, selectedItems) { items, selected ->
+        items.map { SelectableExampleItem(it, it.id in selected) }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        adapter.items = createItems()
         val exampleRenderer = ExampleRenderer {
-            val items = adapter.items.toMutableList()
-            items.remove(it)
-            adapter.updateItems(items)
+            val id = it.data.id
+            val selected = selectedItems.value
+            selectedItems.value = if (id in selected) selected.minus(id)
+            else selected.plus(id)
         }
         adapter.registerRenderer(exampleRenderer)
 
         val recyclerView = findViewById<RecyclerView>(R.id.recyclerView)
         recyclerView.adapter = adapter
         recyclerView.layoutManager = LinearLayoutManager(this)
+
+        selectableItems.onEach { adapter.updateItems(it) }.launchIn(lifecycleScope)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -41,45 +56,69 @@ class MainActivity : AppCompatActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             ITEM_ADD -> {
-                val items = adapter.items.toMutableList()
-                items.add(ExampleItem("What Next?", "X.Y"))
-                adapter.updateItems(items)
+                val oldItems = allItems.value
+                allItems.value = oldItems.plus(ExampleItem(oldItems.size, "What Next?", "X.Y"))
             }
         }
         return super.onOptionsItemSelected(item)
     }
 
-    private fun createItems() : List<ExampleItem> {
+    private fun createItems(): List<ExampleItem> {
         val items = mutableListOf<ExampleItem>()
-        items += ExampleItem("Cupcake", "1.5")
-        items += ExampleItem("Donut", "1.6")
-        items += ExampleItem("Eclair", "2.0")
-        items += ExampleItem("Froyo", "2.2")
-        items += ExampleItem("Gingerbread", "2.3")
-        items += ExampleItem("Honeycomb", "3.0")
-        items += ExampleItem("Ice Cream Sandwich", "4.0")
-        items += ExampleItem("Jelly Bean", "4.1")
-        items += ExampleItem("KitKat", "4.4")
-        items += ExampleItem("Lollipop", "5.0")
-        items += ExampleItem("Marshmallow", "6.0")
-        items += ExampleItem("Nougat", "7.0")
-        items += ExampleItem("Oreo", "8.0")
-        items += ExampleItem("Pie", "9.0")
+        items += ExampleItem(items.size, "Cupcake", "1.5")
+        items += ExampleItem(items.size, "Donut", "1.6")
+        items += ExampleItem(items.size, "Eclair", "2.0")
+        items += ExampleItem(items.size, "Froyo", "2.2")
+        items += ExampleItem(items.size, "Gingerbread", "2.3")
+        items += ExampleItem(items.size, "Honeycomb", "3.0")
+        items += ExampleItem(items.size, "Ice Cream Sandwich", "4.0")
+        items += ExampleItem(items.size, "Jelly Bean", "4.1")
+        items += ExampleItem(items.size, "KitKat", "4.4")
+        items += ExampleItem(items.size, "Lollipop", "5.0")
+        items += ExampleItem(items.size, "Marshmallow", "6.0")
+        items += ExampleItem(items.size, "Nougat", "7.0")
+        items += ExampleItem(items.size, "Oreo", "8.0")
+        items += ExampleItem(items.size, "Pie", "9.0")
         return items
     }
 
     class ExampleRenderer(
-        private val onItemClick: (ExampleItem) -> Unit
-    ) : BindingItemRenderer<ExampleItem, ItemExampleBinding>(
-        ExampleItem::class.java,
+        private val onItemClick: (SelectableExampleItem) -> Unit
+    ) : BindingItemRenderer<SelectableExampleItem, ItemExampleBinding>(
+        SelectableExampleItem::class.java,
         ItemExampleBinding::inflate
     ) {
-        override fun bindView(item: ExampleItem, binding: ItemExampleBinding) {
-            binding.title.text = item.title
-            binding.subtitle.text = item.subtitle
+        override fun bindView(item: SelectableExampleItem, binding: ItemExampleBinding) {
+            val data = item.data
+            binding.title.text = data.title
+            binding.subtitle.text = data.subtitle
             binding.root.setOnClickListener { onItemClick(item) }
+
+            binding.checkbox.isChecked = item.isSelected
+            val translation = if (item.isSelected) 100F else 0F
+            binding.title.translationX = translation
+        }
+
+        override fun updateView(item: SelectableExampleItem, binding: ItemExampleBinding): Boolean {
+            binding.checkbox.isChecked = item.isSelected
+            val translation = if (item.isSelected) 100F else 0F
+            binding.title.animate().translationX(translation)
+            return true
         }
     }
 
-    class ExampleItem(val title: String, val subtitle: String) : Item()
+    data class ExampleItem(
+        val id: Int,
+        val title: String,
+        val subtitle: String
+    ) : Item()
+
+    data class SelectableExampleItem(
+        val data: ExampleItem,
+        val isSelected: Boolean
+    ) : Item() {
+        override fun areItemsTheSame(other: Item): Boolean {
+            return other is SelectableExampleItem && data.id == other.data.id
+        }
+    }
 }

--- a/example/src/main/res/layout/item_example.xml
+++ b/example/src/main/res/layout/item_example.xml
@@ -1,24 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:padding="16dp">
 
     <TextView
         android:id="@+id/title"
+        style="@style/TextAppearance.AppCompat.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        tools:text="Title"
-        style="@style/TextAppearance.AppCompat.Title"/>
+        tools:text="Title" />
 
     <TextView
         android:id="@+id/subtitle"
+        style="@style/TextAppearance.AppCompat.Subhead"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
-        tools:text="Subtitle"
-        style="@style/TextAppearance.AppCompat.Subhead"/>
+        tools:text="Subtitle" />
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
 </LinearLayout>

--- a/itemadapter/src/main/java/com/mattskala/itemadapter/BindingItemRenderer.kt
+++ b/itemadapter/src/main/java/com/mattskala/itemadapter/BindingItemRenderer.kt
@@ -19,6 +19,12 @@ abstract class BindingItemRenderer<M : Item, V : ViewBinding>(
      */
     abstract fun bindView(item: M, binding: V)
 
+    /**
+     * Updates a view to match the new item. Called when only contents of item have changed.
+     * @return true if view was updated, false if full bind should be executed
+     */
+    open fun updateView(item: M, binding: V): Boolean = false
+
     override fun createViewHolder(parent: ViewGroup): BindingViewHolder<V> {
         val inflater = LayoutInflater.from(parent.context)
         val binding = bindingInflater(inflater, parent, false)
@@ -27,6 +33,10 @@ abstract class BindingItemRenderer<M : Item, V : ViewBinding>(
 
     override fun bindView(item: M, holder: BindingViewHolder<V>) {
         bindView(item, holder.binding)
+    }
+
+    override fun updateView(item: M, holder: BindingViewHolder<V>): Boolean {
+        return updateView(item, holder.binding)
     }
 
     override fun onViewRecycled(holder: BindingViewHolder<V>) {

--- a/itemadapter/src/main/java/com/mattskala/itemadapter/Item.kt
+++ b/itemadapter/src/main/java/com/mattskala/itemadapter/Item.kt
@@ -19,6 +19,11 @@ abstract class Item {
     }
 
     /**
+     * Returns a change payload for item that has changed
+     */
+    open fun getChangePayload(other: Item): Any = other
+
+    /**
      * Returns an item type.
      */
     fun getType(): Int {

--- a/itemadapter/src/main/java/com/mattskala/itemadapter/ItemAdapter.kt
+++ b/itemadapter/src/main/java/com/mattskala/itemadapter/ItemAdapter.kt
@@ -1,10 +1,10 @@
 package com.mattskala.itemadapter
 
 import android.util.Log
-import androidx.recyclerview.widget.RecyclerView
 import android.util.SparseArray
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
 
 open class ItemAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     var items = listOf<Item>()
@@ -12,10 +12,13 @@ open class ItemAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     fun registerRenderer(renderer: ItemRenderer<out Item, out RecyclerView.ViewHolder>) {
         if (renderers[renderer.getType()] != null)
-            Log.w("ItemAdapter", "A renderer for this item type (" + renderer.getTypeName() + ") is already registered")
+            Log.w(
+                "ItemAdapter",
+                "A renderer for this item type (" + renderer.getTypeName() + ") is already registered"
+            )
         renderers.put(renderer.getType(), renderer)
     }
-    
+
     fun registerRenderers(vararg renderers: ItemRenderer<*, *>) {
         renderers.forEach(::registerRenderer)
     }
@@ -38,6 +41,10 @@ open class ItemAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             override fun getNewListSize(): Int {
                 return newItems.size
             }
+
+            override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any {
+                return oldItems[oldItemPosition].getChangePayload(newItems[newItemPosition])
+            }
         }, true)
         this.items = newItems
         result.dispatchUpdatesTo(this)
@@ -55,7 +62,18 @@ open class ItemAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         renderer.bindView(item, holder)
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int, payloads: MutableList<Any>) {
+    override fun onBindViewHolder(
+        holder: RecyclerView.ViewHolder,
+        position: Int,
+        payloads: MutableList<Any>
+    ) {
+        if (payloads.firstOrNull() is Item) {
+            val viewType = getItemViewType(position)
+            val item = items[position]
+            val renderer = getRenderer(viewType)
+            val hasUpdated = renderer.updateView(item, holder)
+            if (hasUpdated) return
+        }
         onBindViewHolder(holder, position)
     }
 

--- a/itemadapter/src/main/java/com/mattskala/itemadapter/ItemRenderer.kt
+++ b/itemadapter/src/main/java/com/mattskala/itemadapter/ItemRenderer.kt
@@ -23,6 +23,12 @@ abstract class ItemRenderer<M : Item, VH : RecyclerView.ViewHolder>(
     abstract fun bindView(item: M, holder: VH)
 
     /**
+     * Updates a view to match the new item. Called when only contents of item have changed.
+     * @return true if view was updated, false if full bind should be executed
+     */
+    abstract fun updateView(item: M, holder: VH): Boolean
+
+    /**
      * Called when a view created by this renderer has been recycled.
      * @see RecyclerView.Adapter.onViewRecycled
      */


### PR DESCRIPTION
This will allow to only bind change to existing ViewHolder, which enables creating animations for example. It doesn't support custom logic for creating the change payload, but it's not needed in majority of use cases so I think we should be okay with this.